### PR TITLE
Game engine now supports more illegal moves

### DIFF
--- a/jvm/src/main/scala/govariants/Main.scala
+++ b/jvm/src/main/scala/govariants/Main.scala
@@ -11,8 +11,12 @@ object Main extends App {
 
   while (true) {
     val move = get_move(size)
-    game.play(move.x, move.y)
-    game.display()
+    if (!game.move_is_legal(move.x, move.y)) {
+      println("Move is not legal")
+    } else {
+      game.play(move.x, move.y)
+      game.display()
+    }
   }
 
   def get_move(size: Int): Intersection = {

--- a/shared/src/main/scala/govariants/Board.scala
+++ b/shared/src/main/scala/govariants/Board.scala
@@ -43,17 +43,13 @@ class Board(val size: Int) {
 
   def legal_moves(color: Color): ListBuffer[Intersection] = {
     var _legal_moves: ListBuffer[Intersection] = ListBuffer()
-    for (i <- 0 until size) {
-      for (j <- 0 until size) {
-        if (grid(i)(j) == None) {
-          if (groups.stone_liberties(i, j).size == 0) {
-            if (move_would_capture(i, j, color)) {
-              _legal_moves.append(Intersection(i, j))
-            }
-          } else {
-            _legal_moves.append(Intersection(i, j))
-          }
+    for (i <- 0 until size; j <- 0 until size if grid(i)(j) == None) {
+      if (groups.stone_liberties(i, j).size == 0) {
+        if (move_would_capture(i, j, color)) {
+          _legal_moves.append(Intersection(i, j))
         }
+      } else {
+        _legal_moves.append(Intersection(i, j))
       }
     }
     _legal_moves
@@ -61,7 +57,7 @@ class Board(val size: Int) {
 
   def move_would_capture(x: Int, y: Int, color: Color): Boolean = {
     for (adjacent_group <- groups.adjacent_groups(x, y)) {
-      if (groups.color(adjacent_group) == color.opposite && groups.liberties(adjacent_group) - 1 == 0) {
+      if (groups.color(adjacent_group) == color.opposite && groups.liberties(adjacent_group) == 1) {
         return true
       }
     }

--- a/shared/src/main/scala/govariants/Board.scala
+++ b/shared/src/main/scala/govariants/Board.scala
@@ -41,16 +41,31 @@ class Board(val size: Int) {
     }
   }
 
-  def legal_moves(): ListBuffer[Intersection] = {
+  def legal_moves(color: Color): ListBuffer[Intersection] = {
     var _legal_moves: ListBuffer[Intersection] = ListBuffer()
     for (i <- 0 until size) {
       for (j <- 0 until size) {
         if (grid(i)(j) == None) {
-          _legal_moves.append(Intersection(i, j))
+          if (groups.stone_liberties(i, j).size == 0) {
+            if (move_would_capture(i, j, color)) {
+              _legal_moves.append(Intersection(i, j))
+            }
+          } else {
+            _legal_moves.append(Intersection(i, j))
+          }
         }
       }
     }
     _legal_moves
+  }
+
+  def move_would_capture(x: Int, y: Int, color: Color): Boolean = {
+    for (adjacent_group <- groups.adjacent_groups(x, y)) {
+      if (groups.color(adjacent_group) == color.opposite && groups.liberties(adjacent_group) - 1 == 0) {
+        return true
+      }
+    }
+    false
   }
 
   def add_stone(x: Int, y: Int, color: Color) = {
@@ -89,38 +104,27 @@ class Board(val size: Int) {
   def get_neighbors(x: Int, y: Int): ListBuffer[(Intersection, Idx, Color)] = {
     var neighbors: ListBuffer[(Intersection, Idx, Color)] = ListBuffer()
     if (x > 0) {
-      grid(x - 1)(y) match {
-        case Some(color) =>
-          neighbors ++=
-            ListBuffer((Intersection(x - 1, y), groups.grid(x - 1)(y), color))
-        case None =>
-      }
+      add_neighbor(x - 1, y, neighbors)
     }
     if (x < size - 1) {
-      grid(x + 1)(y) match {
-        case Some(color) =>
-          neighbors ++=
-            ListBuffer((Intersection(x + 1, y), groups.grid(x + 1)(y), color))
-        case None =>
-      }
+      add_neighbor(x + 1, y, neighbors)
     }
     if (y > 0) {
-      grid(x)(y - 1) match {
-        case Some(color) =>
-          neighbors ++=
-            ListBuffer((Intersection(x, y - 1), groups.grid(x)(y - 1), color))
-        case None =>
-      }
+      add_neighbor(x, y - 1, neighbors)
     }
     if (y < size - 1) {
-      grid(x)(y + 1) match {
-        case Some(color) =>
-          neighbors ++=
-            ListBuffer((Intersection(x, y + 1), groups.grid(x)(y + 1), color))
-        case None =>
-      }
+      add_neighbor(x, y + 1, neighbors)
     }
     neighbors
+  }
+
+  def add_neighbor(x: Int, y: Int, neighbors: ListBuffer[(Intersection, Idx, Color)]) = {
+    grid(x)(y) match {
+      case Some(color) =>
+        neighbors ++=
+          ListBuffer((Intersection(x, y), groups.grid(x)(y), color))
+      case None =>
+    }
   }
 
   def remove_group(idx: Idx) = {

--- a/shared/src/main/scala/govariants/Game.scala
+++ b/shared/src/main/scala/govariants/Game.scala
@@ -23,8 +23,12 @@ class Game(val size: Int) {
   }
 
   def start(): List[String] = {
-    legal_moves = board.legal_moves()
+    legal_moves = board.legal_moves(turn)
     compute_playable_action()
+  }
+
+  def move_is_legal(x: Int, y: Int): Boolean = {
+    if (legal_moves.contains(Intersection(x, y))) true else false
   }
 
   def play(x: Int, y: Int): List[String] = {
@@ -32,9 +36,9 @@ class Game(val size: Int) {
 
     board.add_stone(x, y, turn)
 
-    legal_moves = board.legal_moves()
-
     switch_turn()
+    legal_moves = board.legal_moves(turn)
+
     compute_playable_action()
   }
 
@@ -43,10 +47,7 @@ class Game(val size: Int) {
   }
 
   def switch_turn() = {
-    turn = turn match {
-      case Black => White
-      case White => Black
-    }
+    turn = turn.opposite
   }
 
   def display() = {

--- a/shared/src/main/scala/govariants/Game.scala
+++ b/shared/src/main/scala/govariants/Game.scala
@@ -28,7 +28,7 @@ class Game(val size: Int) {
   }
 
   def move_is_legal(x: Int, y: Int): Boolean = {
-    if (legal_moves.contains(Intersection(x, y))) true else false
+    legal_moves.contains(Intersection(x, y))
   }
 
   def play(x: Int, y: Int): List[String] = {

--- a/shared/src/main/scala/govariants/Util.scala
+++ b/shared/src/main/scala/govariants/Util.scala
@@ -1,9 +1,16 @@
 package org.govariants.engine
+import scalajs.js.annotation.{ JSExportTopLevel }
 
 @JSExportTopLevel("Color")
-sealed trait Color
+sealed trait Color {
+  val opposite: Color
+}
 
 @JSExportTopLevel("Black")
-case object Black extends Color
+case object Black extends Color {
+  val opposite: Color = White
+}
 @JSExportTopLevel("White")
-case object White extends Color
+case object White extends Color {
+  val opposite: Color = Black
+}


### PR DESCRIPTION
 - Fix a compilation error coming from the missing "import scalajs"
 - Add an opposite attribute for Color trait
 - Better management of illegal moves in Main.scala
 - Illegal moves support :
    - A move that has no liberty but does capture some opponent stones is
 allowed
    - Otherwise, a move that has no liberty is not allowed
    - Ko moves are still NOT supported
 - Tiny refactor of Board.get_neighbors